### PR TITLE
Add a template for speaker information

### DIFF
--- a/CHECKLISTS.md
+++ b/CHECKLISTS.md
@@ -54,7 +54,7 @@
 
 - [ ] Cleanup the room (empty bottles, collect garbage, order the chairs and tables again, etc.)
 - [ ] Shutdown everything (projector, microphones, windows, doors, etc.)
-- [ ] Collect all utilities (guest badges, sponsor things, etc.) back to our office desks
+- [ ] Collect all utilities (guest badges, sponsor things, etc.) and bring them back to our office desks / reception
 - [ ] Go home and get enough sleep
 
 ## The day after the meetup

--- a/CHECKLISTS.md
+++ b/CHECKLISTS.md
@@ -12,7 +12,7 @@
 
 ## ~2 weeks before the meetup
 
-- [ ] Get in contact with the speaker(s) again to provide more information about
+- [ ] Get in contact with the speaker(s) again to provide more information about (use the [SPEAKER_INFORMATION.md]()./SPEAKER_INFORMATION.md) template)
 	- Technical setup (projector, microphone, etc.)
 	- Address of the location
 	- Date and time of the meetup start
@@ -54,7 +54,7 @@
 
 - [ ] Cleanup the room (empty bottles, collect garbage, order the chairs and tables again, etc.)
 - [ ] Shutdown everything (projector, microphones, windows, doors, etc.)
-- [ ] Collect all utilities (guest badges, sponsor things, etc.) back to our office desks 
+- [ ] Collect all utilities (guest badges, sponsor things, etc.) back to our office desks
 - [ ] Go home and get enough sleep
 
 ## The day after the meetup

--- a/SPEAKER_INFORMATION.md
+++ b/SPEAKER_INFORMATION.md
@@ -1,0 +1,33 @@
+# Information for speaker
+
+Before an event happens, we send out a couple of information to the speaker.
+Below you will find a template.
+
+> Hey all,
+>
+> we like to provide some additional information for the Web Engineering Meetup Düsseldorf for February.
+> First of all: Thanks a lot that you will be a speaker at the WebEngDUS at `<DAY>`, `<DATE>` `<MONTH>` 2018 [1]. We are not able to run such an event without you.
+> Up to now, `<NUMBER-OF-PEOPLE>` people have registered.
+>
+> Here is a bit of additional information:
+
+> * We have two kinds of microphones: Hand mic and a headset. You will be free to choose which one you want to use
+> * We have a Full HD Projector with HDMI connector. If you need an adapter (VGA, DVI, USB-C), please bring it yourself or drop me a message before that we can organize it
+> * The meetup starts at 6:30 pm. The first talk will start at 7:00 pm. Within that 30 min, there will be time to socialize, get a drink or a piece of pizza
+> * We will serve pizza and drinks for free (alcoholic and non-alcoholic)
+> * If you have a long journey to the meetup location and you want to come earlier, ping me. We might be able to arrange a desk for you that you can work before :)
+> * Parking slots are quite rare, public transport is preferred
+> * The meetup takes place at trivago GmbH, 10th floor, Bennigsen-Platz 1, 40474 Düsseldorf
+> * In case of contact, feel free to contact us via
+>    - This email (`<EMAIL-ADDRESSES-OF-ORGANIZERS>`)
+>    - Twitter (@WebEngDUS)
+>    - Mobile Phone: `<MOBILE-NUMBER-OF-ORGANIZERS>`
+
+> If you have a question left, just ping us.
+> Otherwise, we see each other at the Meetup at `<DATE-OF-MEETUP>`.
+> Looking forward!
+>
+> All the best,
+> Andy
+>
+> [1] `<LINK-OF-MEETUP>`

--- a/SPEAKER_INFORMATION.md
+++ b/SPEAKER_INFORMATION.md
@@ -5,17 +5,16 @@ Below you will find a template.
 
 > Hey all,
 >
-> we like to provide some additional information for the Web Engineering Meetup Düsseldorf for February.
-> First of all: Thanks a lot that you will be a speaker at the WebEngDUS at `<DAY>`, `<DATE>` `<MONTH>` 2018 [1]. We are not able to run such an event without you.
+> First of all: Thanks a lot that you will be a speaker at the WebEngDUS at `<DAY>`, `<DATE>`  2018 [1]. Such events would not be possible without you.
 > Up to now, `<NUMBER-OF-PEOPLE>` people have registered.
 >
 > Here is a bit of additional information:
 
-> * We have two kinds of microphones: Hand mic and a headset. You will be free to choose which one you want to use
-> * We have a Full HD Projector with HDMI connector. If you need an adapter (VGA, DVI, USB-C), please bring it yourself or drop me a message before that we can organize it
+> * We have two kinds of microphones: handheld and headset, both wireless. You are free to choose which one you want to use
+> * We have a Full HD Projector with HDMI connector. If you need an adapter (VGA, DVI, USB-C), please bring it yourself or drop me a message before so we can organize one
 > * The meetup starts at 6:30 pm. The first talk will start at 7:00 pm. Within that 30 min, there will be time to socialize, get a drink or a piece of pizza
 > * We will serve pizza and drinks for free (alcoholic and non-alcoholic)
-> * If you have a long journey to the meetup location and you want to come earlier, ping me. We might be able to arrange a desk for you that you can work before :)
+> * If you have a long journey to the meetup location and you want to come earlier, ping me. We might be able to arrange a desk that you can use
 > * Parking slots are quite rare, public transport is preferred
 > * The meetup takes place at trivago GmbH, 10th floor, Bennigsen-Platz 1, 40474 Düsseldorf
 > * In case of contact, feel free to contact us via
@@ -23,9 +22,9 @@ Below you will find a template.
 >    - Twitter (@WebEngDUS)
 >    - Mobile Phone: `<MOBILE-NUMBER-OF-ORGANIZERS>`
 
-> If you have a question left, just ping us.
-> Otherwise, we see each other at the Meetup at `<DATE-OF-MEETUP>`.
-> Looking forward!
+> If you have any questions left, just ping us.
+> Otherwise, we will see each other at the Meetup at `<DATE-OF-MEETUP>`.
+> Looking forward to it!
 >
 > All the best,
 > Andy


### PR DESCRIPTION
More a pragmatic approach to provide a speaker guide.
Maybe a first version, but already helpful because this is in use already.

This is partly related to #7 